### PR TITLE
cloudformation template for creating dynamodb table

### DIFF
--- a/cloudformation/dynamoDB.yml
+++ b/cloudformation/dynamoDB.yml
@@ -1,0 +1,48 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A DynamoDB template for high availability HoneyELB 
+Parameters:
+  DynamoReadCapacityUnits: 
+    Description: "Provisioned read throughput"
+    Type: "Number"
+    Default: "1"
+    MinValue: "1"
+    MaxValue: "10000"
+    ConstraintDescription: "must be between 1 and 10000"
+  DynamoWriteCapacityUnits: 
+    Description: "Provisioned read throughput"
+    Type: "Number"
+    Default: "1"
+    MinValue: "1"
+    MaxValue: "10000"
+    ConstraintDescription: "must be between 1 and 10000"
+Resources:
+  HoneyELBAccessLogBuckets:
+    Type: "AWS::DynamoDB::Table"
+    Properties: 
+      TableName: "HoneyELBAccessLogBuckets"
+      AttributeDefinitions: 
+        - 
+          AttributeName: "S3object"
+          AttributeType: "S"
+        - 
+          AttributeName: "Time"
+          AttributeType: "S"
+      KeySchema: 
+        -
+          AttributeName: "S3object"
+          KeyType: "HASH"
+        -
+          AttributeName: "Time"
+          KeyType: "RANGE"
+      ProvisionedThroughput: 
+        ReadCapacityUnits:  
+          Ref: "DynamoReadCapacityUnits"
+        WriteCapacityUnits: 
+          Ref: "DynamoWriteCapacityUnits"
+Outputs:
+  TableName:
+    Value: !Ref HoneyELBAccessLogBuckets 
+    Description: "Table name of the newly created DynamoDB table"
+  
+
+  


### PR DESCRIPTION
Using this cloudformation template, a user can create the dynamoDB table necessary for high availability log ingestion. 
```
aws cloudformation create-stack --stack-name DynamoDBHoneyELB --template-body file://cloudformation/dynamoDB.yml
```