### PR TITLE
add urlshaper parsed fields if they exist

### DIFF
--- a/publisher/request_shaper.go
+++ b/publisher/request_shaper.go
@@ -44,5 +44,8 @@ func (rs *requestShaper) Shape(field string, ev *event.Event) {
 		if res.QueryShape != "" {
 			ev.Data[field+"_queryshape"] = res.QueryShape
 		}
+		for k, v := range res.PathFields {
+			ev.Data[field+"_path_"+k] = v[0]
+		}
 	}
 }


### PR DESCRIPTION
Turns out that though we do URL shaping in `honeyaws`, we don't actually do anything with any variables that might have been specified in a routes listing.  We should add those as fields, if they exist.