### PR TITLE
Update packaging scripts to include new binaries

### DIFF
--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -31,7 +31,13 @@ fpm -s dir -n honeyaws \
     --pre-install=./preinstall \
     $GOPATH/bin/honeyelb=/usr/bin/honeyelb \
     $GOPATH/bin/honeycloudfront=/usr/bin/honeycloudfront \
+    $GOPATH/bin/honeycloudtrail=/usr/bin/honeycloudtrail \
+    $GOPATH/bin/honeyalb=/usr/bin/honeyalb \
     ./service/honeycloudfront.upstart=/etc/init/honeycloudfront.conf \
     ./service/honeycloudfront.service=/lib/systemd/system/honeycloudfront.service \
     ./service/honeyelb.upstart=/etc/init/honeyelb.conf \
-    ./service/honeyelb.service=/lib/systemd/system/honeyelb.service
+    ./service/honeyelb.service=/lib/systemd/system/honeyelb.service \
+    ./service/honeycloudtrail.upstart=/etc/init/honeycloudtrail.conf \
+    ./service/honeycloudtrail.service=/lib/systemd/system/honeycloudtrail.service \
+    ./service/honeyalb.upstart=/etc/init/honeyalb.conf \
+    ./service/honeyalb.service=/lib/systemd/system/honeyalb.service

--- a/preinstall
+++ b/preinstall
@@ -29,3 +29,5 @@ fi
 usermod -a -G adm honeycomb
 install -d -o honeycomb -g honeycomb /var/lib/honeyelb
 install -d -o honeycomb -g honeycomb /var/lib/honeycloudformation
+install -d -o honeycomb -g honeycomb /var/lib/honeycloudtrail
+install -d -o honeycomb -g honeycomb /var/lib/honeyalb

--- a/service/honeyalb.service
+++ b/service/honeyalb.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Honeycomb ALB Agent
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/honeyalb --statedir /var/lib/honeyalb ingest
+KillMode=process
+Restart=on-failure
+User=honeycomb
+Group=honeycomb
+
+[Install]
+Alias=honeyalb honeyalb.service

--- a/service/honeyalb.upstart
+++ b/service/honeyalb.upstart
@@ -1,0 +1,12 @@
+# Upstart job for honeyalb
+# https://honeycomb.io/
+
+description     "HoneyALB Daemon"
+author          "Nathan LeClaire <nathan@honeycomb.io>"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+exec su -s /bin/sh -c 'exec "$0" "$@"' honeycomb -- /usr/bin/honeyalb --statedir /var/lib/honeyalb ingest

--- a/service/honeycloudtrail.service
+++ b/service/honeycloudtrail.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Honeycomb CloudTrail Agent
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/honeycloudtrail --statedir /var/lib/honeycloudtrail ingest
+KillMode=process
+Restart=on-failure
+User=honeycomb
+Group=honeycomb
+
+[Install]
+Alias=honeycloudtrail honeycloudtrail.service

--- a/service/honeycloudtrail.upstart
+++ b/service/honeycloudtrail.upstart
@@ -1,0 +1,12 @@
+# Upstart job for honeycloudtrail
+# https://honeycomb.io/
+
+description     "Honeycomb CloudTrail Daemon"
+author          "Susan Lunn <susan@honeycomb.io>"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+exec su -s /bin/sh -c 'exec "$0" "$@"' honeycomb -- /usr/bin/honeycloudtrail --statedir /var/lib/honeycloudtrail ingest


### PR DESCRIPTION
This updates `honeycloudtrail` and `honeyalb` to be bundled in the deb and RPM packages we distribute.