### PR TITLE
deleting timestamp as range key

### DIFF
--- a/cloudformation/dynamoDB.yml
+++ b/cloudformation/dynamoDB.yml
@@ -24,16 +24,10 @@ Resources:
         -
           AttributeName: "S3Object"
           AttributeType: "S"
-        - 
-          AttributeName: "Time"
-          AttributeType: "S"
       KeySchema:
         -
           AttributeName: "S3Object"
           KeyType: "HASH"
-        -
-          AttributeName: "Time"
-          KeyType: "RANGE"
       ProvisionedThroughput:
         ReadCapacityUnits:
           Ref: "DynamoReadCapacityUnits"


### PR DESCRIPTION
Fixes [issue 42](https://github.com/honeycombio/honeyaws/issues/42). 

The Cloudformation stack we were using created a partition key that's hash was the S3Object and range the time stamp. As a result, when we attempted to do `attribute_not_exists(S3Object)`, and not specifying the `range` of the partition key as well - it would return true every time. As a result of returning true, duplicates were being sent to Honeycomb. 

Luckily, you can shove arbitrary keys into DynamoDB - they don't need to be specified in the schema. Deleting the range key was sufficient to let `attribute_not_exists(HASH)` actually work! 

```
 $ ./honeyelb --writekey=<> --dataset="susan-honeyelb-test" ingest shepherd-dogfood-lb --highavail
INFO[2018-04-04T16:49:39-04:00] High availability enabled - using DynamoDB
INFO[2018-04-04T16:49:39-04:00] Attempting to ingest LB                       lbName=shepherd-dogfood-lb
INFO[2018-04-04T16:49:39-04:00] Access logs are enabled for ELB ♥             bucket=honeycomb-elb-access-logs lbName=shepherd-dogfood-lb
INFO[2018-04-04T16:49:39-04:00] Getting recent objects                        entity=shepherd-dogfood-lb prefix=shepherd-dogfood/AWSLogs/702835727665/elasticloadbalancing/us-east-1/2018/04/04/702835727665_elasticloadbalancing_us-east-1_shepherd-dogfood-lb
INFO[2018-04-04T16:49:41-04:00] Downloading access logs from object           entity=shepherd-dogfood-lb from_time_ago=58m49.676843551s key=shepherd-dogfood/AWSLogs/702835727665/elasticloadbalancing/us-east-1/2018/04/04/702835727665_elasticloadbalancing_us-east-1_shepherd-dogfood-lb_20180404T1950Z_107.23.163.113_p38q5by4.log size=2679656

INFO[2018-04-04T16:50:03-04:00] Successfully downloaded object                bytes=2679656 entity=shepherd-dogfood-lb file=/var/folders/4n/vsg2kv29217bmh6w39nykqdr0000gn/T/hc-entity-ingest725125499
INFO[2018-04-04T16:50:03-04:00] Downloading access logs from object           entity=shepherd-dogfood-lb from_time_ago=59m36.460733336s key=shepherd-dogfood/AWSLogs/702835727665/elasticloadbalancing/us-east-1/2018/04/04/702835727665_elasticloadbalancing_us-east-1_shepherd-dogfood-lb_20180404T1950Z_34.195.58.155_397ihwie.log size=3074695
INFO[2018-04-04T16:50:25-04:00] Successfully downloaded object                bytes=3074695 entity=shepherd-dogfood-lb file=/var/folders/4n/vsg2kv29217bmh6w39nykqdr0000gn/T/hc-entity-ingest480236702
INFO[2018-04-04T16:50:25-04:00] Downloading access logs from object           entity=shepherd-dogfood-lb from_time_ago=1h0m18.370755078s key=shepherd-dogfood/AWSLogs/702835727665/elasticloadbalancing/us-east-1/2018/04/04/702835727665_elasticloadbalancing_us-east-1_shepherd-dogfood-lb_20180404T1950Z_35.169.76.44_4q0527ei.log size=3142389
INFO[2018-04-04T16:51:01-04:00] Successfully downloaded object                bytes=3142389 entity=shepherd-dogfood-lb file=/var/folders/4n/vsg2kv29217bmh6w39nykqdr0000gn/T/hc-entity-ingest790605669
INFO[2018-04-04T16:51:01-04:00] Downloading access logs from object           entity=shepherd-dogfood-lb from_time_ago=1h0m35.618356953s key=shepherd-dogfood/AWSLogs/702835727665/elasticloadbalancing/us-east-1/2018/04/04/702835727665_elasticloadbalancing_us-east-1_shepherd-dogfood-lb_20180404T1950Z_52.206.210.233_4e4h52pv.log size=4181674

INFO[2018-04-04T16:51:44-04:00] Successfully downloaded object                bytes=4181674 entity=shepherd-dogfood-lb file=/var/folders/4n/vsg2kv29217bmh6w39nykqdr0000gn/T/hc-entity-ingest475135360
INFO[2018-04-04T16:51:44-04:00] Downloading access logs from object           entity=shepherd-dogfood-lb from_time_ago=56m32.961905802s key=shepherd-dogfood/AWSLogs/702835727665/elasticloadbalancing/us-east-1/2018/04/04/702835727665_elasticloadbalancing_us-east-1_shepherd-dogfood-lb_20180404T1955Z_107.23.163.113_4zmpzz66.log size=3333937

^CFATA[2018-04-04T16:52:02-04:00] Exiting due to interrupt.
[  4:52PM ]  [ susan@schoolbook:~/go/src/github.com/honeycombio/honeyaws(susanlunn.fix-duplicates✗) ]
 $ ./honeyelb --writekey=<> --dataset="susan-honeyelb-test" ingest shepherd-dogfood-lb --highavail
INFO[2018-04-04T16:52:05-04:00] High availability enabled - using DynamoDB
INFO[2018-04-04T16:52:05-04:00] Attempting to ingest LB                       lbName=shepherd-dogfood-lb
INFO[2018-04-04T16:52:05-04:00] Access logs are enabled for ELB ♥             bucket=honeycomb-elb-access-logs lbName=shepherd-dogfood-lb
INFO[2018-04-04T16:52:09-04:00] Getting recent objects                        entity=shepherd-dogfood-lb prefix=shepherd-dogfood/AWSLogs/702835727665/elasticloadbalancing/us-east-1/2018/04/04/702835727665_elasticloadbalancing_us-east-1_shepherd-dogfood-lb
INFO[2018-04-04T16:52:12-04:00] Downloading access logs from object           entity=shepherd-dogfood-lb from_time_ago=57m0.382875045s key=shepherd-dogfood/AWSLogs/702835727665/elasticloadbalancing/us-east-1/2018/04/04/702835727665_elasticloadbalancing_us-east-1_shepherd-dogfood-lb_20180404T1955Z_107.23.163.113_4zmpzz66.log size=3333937
```

![image](https://user-images.githubusercontent.com/3599795/38337300-c002a6ec-3832-11e8-9d6e-c36ddceca1e4.png)

We were able to test it on @tredman's awesome k8s cluster, and so far - no dupes!