### PR TITLE
[honeycloudtrail] include request parameters in cloudtrail events

### DIFF
--- a/publisher/cloudtrail.go
+++ b/publisher/cloudtrail.go
@@ -33,15 +33,16 @@ type CloudTrailRecords struct {
 }
 
 type CloudTrailRecord struct {
-	UserIdentity    CloudTrailUserIdentity `json:userIdentity`
-	EventTime       string                 `json:eventTime`
-	EventSource     string                 `json:eventSource`
-	EventName       string                 `json:eventName`
-	AwsRegion       string                 `json:awsRegion`
-	SourceIPAddress string                 `json:sourceIPAddress`
-	UserAgent       string                 `json:userAgent`
-	Resources       []CloudTrailResource   `json:resources`
-	EventType       string                 `json:eventType`
+	UserIdentity      CloudTrailUserIdentity `json:"userIdentity"`
+	EventTime         string                 `json:"eventTime"`
+	EventSource       string                 `json:"eventSource"`
+	EventName         string                 `json:"eventName"`
+	AwsRegion         string                 `json:"awsRegion"`
+	SourceIPAddress   string                 `json:"sourceIPAddress"`
+	UserAgent         string                 `json:"userAgent"`
+	Resources         []CloudTrailResource   `json:"resources"`
+	EventType         string                 `json:"eventType"`
+	RequestParameters map[string]interface{} `json:"requestParameters"`
 }
 
 type CloudTrailEventParser struct {
@@ -65,6 +66,7 @@ func flattenCloudTrailRecord(r *CloudTrailRecord) map[string]interface{} {
 	p["SourceIPAddress"] = r.SourceIPAddress
 	p["UserAgent"] = r.UserAgent
 	p["EventType"] = r.EventType
+	p["Parameters"] = r.RequestParameters
 
 	return p
 }


### PR DESCRIPTION
Without the request parameters, a lot of context is missing for certain events. For example, for SSM:GetParameter, I want to know what parameter was requested. For S3:GetObject, knowing the bucket/key that was requested is helpful.