### PR TITLE
Change ordering of processed

### DIFF
--- a/cloudformation/dynamoDB.yml
+++ b/cloudformation/dynamoDB.yml
@@ -4,17 +4,17 @@ Parameters:
   DynamoReadCapacityUnits:
     Description: "Provisioned read throughput"
     Type: "Number"
-    Default: "1"
+    Default: "10"
     MinValue: "1"
     MaxValue: "10000"
-    ConstraintDescription: "must be between 1 and 10000"
+    ConstraintDescription: "must be between 1 and 100000"
   DynamoWriteCapacityUnits:
     Description: "Provisioned read throughput"
     Type: "Number"
-    Default: "1"
+    Default: "10"
     MinValue: "1"
     MaxValue: "10000"
-    ConstraintDescription: "must be between 1 and 10000"
+    ConstraintDescription: "must be between 1 and 100000"
 Resources:
   HoneyAWSAccessLogBuckets:
     Type: "AWS::DynamoDB::Table"

--- a/logbucket/logbucket.go
+++ b/logbucket/logbucket.go
@@ -234,6 +234,13 @@ func (d *Downloader) accessLogBucketPageCallback(processedObjects map[string]tim
 		}
 
 		if time.Since(*obj.LastModified) < d.BackfillInterval {
+			if err := d.SetProcessed(*obj.Key); err != nil {
+				logrus.Debug("Error setting state of object as processed: ", *obj.Key)
+				continue
+			}
+			// we want to set the object as processed as
+			// soon as it's ready to downloaded
+			// to avoid duplicates in downloading
 			d.ObjectsToDownload <- obj
 		}
 	}

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -188,10 +188,6 @@ func (hp *HoneycombPublisher) Publish(downloadedObj state.DownloadedObject) erro
 		return fmt.Errorf("Error cleaning up downloaded object %s: %s", downloadedObj.Filename, err)
 	}
 
-	if err := hp.Stater.SetProcessed(downloadedObj.Object); err != nil {
-		return fmt.Errorf("Error setting state of object as processed: %s", err)
-	}
-
 	return nil
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -145,7 +145,9 @@ func (d *DynamoDBStater) SetProcessed(s3object string) error {
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
 			// we want this to happen if object already exists
-			if awsErr.Code() != dynamodb.ErrCodeConditionalCheckFailedException {
+			if awsErr.Code() == dynamodb.ErrCodeConditionalCheckFailedException {
+				return fmt.Errorf("Item exists in Dynamo: %s", err)
+			} else {
 				return fmt.Errorf("PutItem failed: %s", err)
 			}
 


### PR DESCRIPTION
Currently an issue exists within the HA implementation where if multiple
agents are started concurrently, they don't have time to set the object
their downloading to "Processed". By changing the ordering of when we
set an object to processed - before it's downloaded, other threads will
be able to see that the object is being worked on or is already
published.

The caveat here is that if an object fails to publish or download
correctly, it will already be set to "processed". The trade off is
either publishing duplicates, or losing a log or two.