### PR TITLE
compute wallclock duration for ALB events

### DIFF
--- a/publisher/alb_test.go
+++ b/publisher/alb_test.go
@@ -1,0 +1,85 @@
+package publisher
+
+import (
+	"compress/gzip"
+	"io/ioutil"
+	"log"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/honeycombio/honeyaws/options"
+	"github.com/honeycombio/honeyaws/state"
+	"github.com/honeycombio/honeytail/event"
+)
+
+func TestALBParseEvents(t *testing.T) {
+	elbPubisher := NewALBEventParser(&options.Options{SampleRate: 1, SamplerType: "simple"})
+	outCh := make(chan event.Event)
+	tmpFile, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal("Shouldn't have err but did: ", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	zipper := gzip.NewWriter(tmpFile)
+	if _, err := zipper.Write([]byte(`h2 2017-07-31T20:30:57.975041Z spline_reticulation_lb 10.11.12.13:47882 10.3.47.87:8080 0.000021 0.010962 -1 504 504 766 17 "PUT https://api.simulation.io:443/reticulate/spline/1 HTTP/1.1" "libhoney-go/1.3.3" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 groupARN "Root=1-5e71404d-84277a47a826ab3d2e844170" "ui-dogfood.honeycomb.io" "certARN" 0 2017-07-31T20:30:52.975041Z "forward" "-" "-" "10.11.12.13:80" "201"`)); err != nil {
+		t.Fatal("Shouldn't have err but did: ", err)
+	}
+	if err := zipper.Close(); err != nil {
+		t.Fatal("Shouldn't have err but did: ", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatal("Shouldn't have err but did: ", err)
+	}
+	obj := state.DownloadedObject{
+		Object:   "foo",
+		Filename: tmpFile.Name(),
+	}
+	if err := elbPubisher.ParseEvents(obj, outCh); err != nil {
+		t.Fatal("Shouldn't have err but did: ", err)
+	}
+	expected := map[string]interface{}{
+		"type":                    "h2",
+		"client_authority":        "10.11.12.13:47882",
+		"backend_authority":       "10.3.47.87:8080",
+		"sent_bytes":              int64(17),
+		"ssl_protocol":            "TLSv1.2",
+		"request_processing_time": 2.1e-05,
+		"request":                 "PUT https://api.simulation.io:443/reticulate/spline/1 HTTP/1.1",
+		"user_agent":              "libhoney-go/1.3.3",
+		"backend_processing_time": 0.010962,
+		"elb": "spline_reticulation_lb",
+		"backend_status_code":      int64(504),
+		"elb_status_code":          int64(504),
+		"response_processing_time": int64(-1),
+		"received_bytes":           int64(766),
+		"ssl_cipher":               "ECDHE-RSA-AES128-GCM-SHA256",
+		"request_creation_time":    "2017-07-31T20:30:52.975041Z",
+		"trace_id":                 "Root=1-5e71404d-84277a47a826ab3d2e844170",
+		"domain_name":              "ui-dogfood.honeycomb.io",
+		"matched_rule_priority":    int64(0),
+		"chosen_cert_arn":          "certARN",
+		"target_group_arn":         "groupARN",
+	}
+	ev := <-outCh
+	close(outCh)
+
+	if !reflect.DeepEqual(ev.Data, expected) {
+		t.Error("Output did not match expected:")
+		for k, v := range ev.Data {
+			if reflect.DeepEqual(v, expected[k]) {
+				continue
+			}
+			log.Print("actual: ", k, "\t(", reflect.TypeOf(v), ") ", v)
+			log.Print("expected: ", k, "\t(", reflect.TypeOf(expected[k]), ") ", expected[k])
+		}
+		t.Fatal()
+	}
+
+	excpectedDurMs := 5000.0
+	addTraceData(&ev)
+	if ev.Data["duration_ms"] != excpectedDurMs {
+		t.Fatalf("actual duration_ms: %v, expected: %v", ev.Data["duration_ms"], excpectedDurMs)
+	}
+}

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -31,10 +31,16 @@ var (
 	// Example CloudFront log format (aws_cf_web):
 	// 2014-05-23 01:13:11 FRA2 182 192.0.2.10 GET d111111abcdef8.cloudfront.net /view/my/file.html 200 www.displaymyfiles.com Mozilla/4.0%20(compatible;%20MSIE%205.0b1;%20Mac_PowerPC) - zip=98101 RefreshHit MRVMF7KydIvxMWfJIglgwHQwZsbG2IhRJ07sn9AkKUFSHS9EXAMPLE== d111111abcdef8.cloudfront.net http - 0.001 - - - RefreshHit HTTP/1.1
 
+	// TODO find creation time in here, make sure it's recorded, us it for duration
 	// TODO: update $unknown field once ALB documentation is updated
-	logFormat = []byte(fmt.Sprintf(`log_format %s '$timestamp $elb $client_authority $backend_authority $request_processing_time $backend_processing_time $response_processing_time $elb_status_code $backend_status_code $received_bytes $sent_bytes "$request" "$user_agent" $ssl_cipher $ssl_protocol';
+	logFormat = []byte(fmt.Sprintf(
+		`log_format %s '$timestamp $elb $client_authority $backend_authority $request_processing_time $backend_processing_time $response_processing_time $elb_status_code $backend_status_code $received_bytes $sent_bytes "$request" "$user_agent" $ssl_cipher $ssl_protocol';
 log_format %s '$timestamp $x_edge_location $sc_bytes $c_ip $cs_method $cs_host $cs_uri_stem $sc_status $cs_referer $cs_user_agent $cs_uri_query $cs_cookie $x_edge_result_type $x_edge_request_id $x_host_header $cs_protocol $cs_bytes $time_taken $x_forwarded_for $ssl_protocol $ssl_cipher $x_edge_response_result_type $cs_protocol_version';
-log_format %s '$type $timestamp $elb $client_authority $backend_authority $request_processing_time $backend_processing_time $response_processing_time $elb_status_code $backend_status_code $received_bytes $sent_bytes "$request" "$user_agent" $ssl_cipher $ssl_protocol $target_group_arn "$trace_id" $domain_name $chosen_cert_arn $unknown';`, AWSElasticLoadBalancerFormat, AWSCloudFrontWebFormat, AWSApplicationLoadBalancerFormat))
+log_format %s '$type $timestamp $elb $client_authority $backend_authority $request_processing_time $backend_processing_time $response_processing_time $elb_status_code $backend_status_code $received_bytes $sent_bytes "$request" "$user_agent" $ssl_cipher $ssl_protocol $target_group_arn "$trace_id" "$domain_name" "$chosen_cert_arn" $matched_rule_priority $request_creation_time';`,
+		AWSElasticLoadBalancerFormat,
+		AWSCloudFrontWebFormat,
+		AWSApplicationLoadBalancerFormat,
+	))
 	libhoneyInitialized = false
 	formatFileName      string
 )
@@ -190,9 +196,24 @@ func addTraceData(ev *event.Event) {
 	if rootSpan {
 		ev.Data["trace.span_id"] = ev.Data["trace.trace_id"].(string)
 	}
-	if durationMs, ok := ev.Data["request_processing_time"].(float64); ok {
+
+	var durationMs float64
+	if startTime, ok := ev.Data["request_creation_time"].(string); ok {
+		tm, err := time.Parse(time.RFC3339Nano, startTime)
+		if err == nil {
+			duration := ev.Timestamp.Sub(tm)
+			if duration > 0 {
+				durationMs = float64(duration / time.Millisecond)
+			}
+		}
+	}
+	if durationMs == 0.0 {
+		durationMs, _ = ev.Data["request_processing_time"].(float64)
+	}
+	if durationMs > 0.0 {
 		ev.Data["duration_ms"] = durationMs
 	}
+
 	if elb, ok := ev.Data["elb"].(string); ok {
 		ev.Data["service_name"] = elb
 	}

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -31,8 +31,6 @@ var (
 	// Example CloudFront log format (aws_cf_web):
 	// 2014-05-23 01:13:11 FRA2 182 192.0.2.10 GET d111111abcdef8.cloudfront.net /view/my/file.html 200 www.displaymyfiles.com Mozilla/4.0%20(compatible;%20MSIE%205.0b1;%20Mac_PowerPC) - zip=98101 RefreshHit MRVMF7KydIvxMWfJIglgwHQwZsbG2IhRJ07sn9AkKUFSHS9EXAMPLE== d111111abcdef8.cloudfront.net http - 0.001 - - - RefreshHit HTTP/1.1
 
-	// TODO find creation time in here, make sure it's recorded, us it for duration
-	// TODO: update $unknown field once ALB documentation is updated
 	logFormat = []byte(fmt.Sprintf(
 		`log_format %s '$timestamp $elb $client_authority $backend_authority $request_processing_time $backend_processing_time $response_processing_time $elb_status_code $backend_status_code $received_bytes $sent_bytes "$request" "$user_agent" $ssl_cipher $ssl_protocol';
 log_format %s '$timestamp $x_edge_location $sc_bytes $c_ip $cs_method $cs_host $cs_uri_stem $sc_status $cs_referer $cs_user_agent $cs_uri_query $cs_cookie $x_edge_result_type $x_edge_request_id $x_host_header $cs_protocol $cs_bytes $time_taken $x_forwarded_for $ssl_protocol $ssl_cipher $x_edge_response_result_type $cs_protocol_version';


### PR DESCRIPTION
This changes how `duration_ms` is computed for ALB logs. According to the docs, `request_creation_time` is the time when the load balancer first gets the request. `timestamp` is poorly defined, but appears to correspond to when the event is actually finished. Therefor, comparing the two should allow us to see the actual transmission duration as observed by the client. I confirmed that a very long (multi-minute) download I performed does in fact have a multi-minute duration using this calculation.

This could be viewed as a breaking change. If we don't want that, I could put this duration in a different field; however, I think this number is more correct, and we still have the `response_processing_time` field.

Also add a test for ALB logs, and add parenthesis to a couple of fields which didn't have them.