### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+
+# For anything not explicitly taken by someone else:
+* @nathanleclaire


### PR DESCRIPTION
Adds a codeowners file to ensure appropriate people / teams are added as reviewers. I've initially added @nathanleclaire.

@maplebed @paulosman Is there anyone else / team who we should add?