### PR TITLE
Add support for edge mode

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -7,6 +7,7 @@ type Options struct {
 	StateDir        string  `long:"statedir" description:"Directory where ingest state is stored" default:"."`
 	HighAvail       bool    `long:"highavail" description:"Enable high availability ingestion using DynamoDB"`
 	BackfillHr      int     `long:"backfill" description:"The number of hours to increase backfill of log ingestion to with max of 168 hours (1 week)" default:"1"`
+	EdgeMode        bool    `long:"edge_mode" description:"Ignore any parent trace id, if present, from a load balancer"`
 	SamplerType     string  `long:"sampler_type" default:"simple" description:"Type of dynamic sampler to use. Options are 'simple' and 'ema'"`
 	SamplerInterval int     `long:"sampler_interval" default:"300" description:"Interval between sample rate calculation, in seconds."`
 	SamplerDecay    float64 `long:"sampler_decay" default:"0.5" description:"Used only when sampler_type is set to 'ema'. A value between (0,1) that controls how fast new observations are factored into the moving average. Larger values mean the sample rates are more sensitive to recent observations."`

--- a/publisher/alb_test.go
+++ b/publisher/alb_test.go
@@ -78,7 +78,7 @@ func TestALBParseEvents(t *testing.T) {
 	}
 
 	excpectedDurMs := 5000.0
-	addTraceData(&ev)
+	addTraceData(&ev, false)
 	if ev.Data["duration_ms"] != excpectedDurMs {
 		t.Fatalf("actual duration_ms: %v, expected: %v", ev.Data["duration_ms"], excpectedDurMs)
 	}

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -92,6 +92,87 @@ func TestParseTraceData(t *testing.T) {
 	}
 }
 
+func TestParseTraceDataEdgeMode(t *testing.T) {
+	testCases := []struct {
+		ev       event.Event
+		expected map[string]interface{}
+	}{
+		{
+			ev: event.Event{
+				Data: map[string]interface{}{
+					"trace_id":                "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Self=1-67891234-12456789abcdef012345678;Sampled=1",
+					"request_processing_time": 1.12,
+					"elb":                     "app/foo-alb/1db0c9806095122a",
+					"request_path":            "/down/stream",
+				},
+			},
+			expected: map[string]interface{}{
+				// old fields
+				"request.headers.x-amzn-trace-id": "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Self=1-67891234-12456789abcdef012345678;Sampled=1",
+				"request_processing_time":         1.12,
+				"elb":                             "app/foo-alb/1db0c9806095122a",
+				"request_path":                    "/down/stream",
+				"trace.trace_id":                  "1-5759e988-bd862e3fe1be46a994272793",
+				"trace.span_id":                   "1-67891234-12456789abcdef012345678",
+				"duration_ms":                     1.12,
+				"sampled":                         "1",
+				"service_name":                    "app/foo-alb/1db0c9806095122a",
+				"name":                            "/down/stream",
+			},
+		},
+		{
+			ev: event.Event{
+				Data: map[string]interface{}{
+					// trace id contains some garbage - should not crash
+					"trace_id": "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Self=1-67891234-12456789abcdef012345678;Sampled=1;shouldnotcrash",
+					// request time is a string, not a float - should not crash
+					"request_processing_time": "1.12",
+					// elb is not a string, should not crash
+					"elb": 1,
+					// request_path is the wrong type - should not crash
+					"request_path": false,
+				},
+			},
+			expected: map[string]interface{}{
+				"request.headers.x-amzn-trace-id": "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Self=1-67891234-12456789abcdef012345678;Sampled=1;shouldnotcrash",
+				"request_processing_time":         "1.12",
+				"elb":                             1,
+				"request_path":                    false,
+				"trace.trace_id":                  "1-5759e988-bd862e3fe1be46a994272793",
+				"trace.span_id":                   "1-67891234-12456789abcdef012345678",
+				"sampled":                         "1",
+			},
+		},
+		{
+			ev: event.Event{
+				Data: map[string]interface{}{
+					"trace_id": "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Self=1-67891234-12456789abcdef012345678;Sampled=1",
+					// request processing time, request path, and elb missing - should not crash
+				},
+			},
+			expected: map[string]interface{}{
+				// old fields
+				"request.headers.x-amzn-trace-id": "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Self=1-67891234-12456789abcdef012345678;Sampled=1",
+				"trace.trace_id":                  "1-5759e988-bd862e3fe1be46a994272793",
+				"trace.span_id":                   "1-67891234-12456789abcdef012345678",
+				"sampled":                         "1",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		addTraceData(&tc.ev, true)
+		if !reflect.DeepEqual(tc.ev.Data, tc.expected) {
+			t.Error("Output did not match expected:")
+			for k, v := range tc.ev.Data {
+				log.Print("actual: ", k, "\t(", reflect.TypeOf(v), ") ", v)
+				log.Print("expected: ", k, "\t(", reflect.TypeOf(tc.expected[k]), ") ", tc.expected[k])
+			}
+			t.Fatal()
+		}
+	}
+}
+
 func TestDropNegativeTimes(t *testing.T) {
 	testCases := []struct {
 		ev       event.Event

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -80,7 +80,7 @@ func TestParseTraceData(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		addTraceData(&tc.ev)
+		addTraceData(&tc.ev, false)
 		if !reflect.DeepEqual(tc.ev.Data, tc.expected) {
 			t.Error("Output did not match expected:")
 			for k, v := range tc.ev.Data {


### PR DESCRIPTION
When run in edge mode, honeyalb and honeyelb will ignore the parent_id segment of Amazon trace headers. This prevents requests from the public internet containing amazon headers from resulting in broken traces (missing root spans). 