### PR TITLE
User public ENV context in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ workflows:
     jobs:
       - build
       - publish_github:
-          context: Honeycomb Secrets
+          context: Honeycomb Secrets for Public Repos
           requires:
             - build
           filters:
@@ -80,7 +80,7 @@ workflows:
             branches:
               ignore: /.*/
       - publish_s3:
-          context: Honeycomb Secrets
+          context: Honeycomb Secrets for Public Repos
           requires:
             - build
           filters:


### PR DESCRIPTION
We created a new context in Circle for public repos (Honeycomb Secrets for Public Repos), which is identical to the Honeycomb Secrets, with the exception of the Github token, which has more restrictive privileges (only public repos).

This will continue to allow builds to publish Github releases in the public repos, without exposing access to private repos.