### PR TITLE
Set timestamp variable to the request_creation_time and old timestamp…

### DIFF
--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -34,7 +34,7 @@ var (
 	logFormat = []byte(fmt.Sprintf(
 		`log_format %s '$timestamp $elb $client_authority $backend_authority $request_processing_time $backend_processing_time $response_processing_time $elb_status_code $backend_status_code $received_bytes $sent_bytes "$request" "$user_agent" $ssl_cipher $ssl_protocol';
 log_format %s '$timestamp $x_edge_location $sc_bytes $c_ip $cs_method $cs_host $cs_uri_stem $sc_status $cs_referer $cs_user_agent $cs_uri_query $cs_cookie $x_edge_result_type $x_edge_request_id $x_host_header $cs_protocol $cs_bytes $time_taken $x_forwarded_for $ssl_protocol $ssl_cipher $x_edge_response_result_type $cs_protocol_version';
-log_format %s '$type $timestamp $elb $client_authority $backend_authority $request_processing_time $backend_processing_time $response_processing_time $elb_status_code $backend_status_code $received_bytes $sent_bytes "$request" "$user_agent" $ssl_cipher $ssl_protocol $target_group_arn "$trace_id" "$domain_name" "$chosen_cert_arn" $matched_rule_priority $request_creation_time';`,
+log_format %s '$type $response_time $elb $client_authority $backend_authority $request_processing_time $backend_processing_time $response_processing_time $elb_status_code $backend_status_code $received_bytes $sent_bytes "$request" "$user_agent" $ssl_cipher $ssl_protocol $target_group_arn "$trace_id" "$domain_name" "$chosen_cert_arn" $matched_rule_priority $timestamp';`,
 		AWSElasticLoadBalancerFormat,
 		AWSCloudFrontWebFormat,
 		AWSApplicationLoadBalancerFormat,
@@ -198,10 +198,10 @@ func addTraceData(ev *event.Event, edgeMode bool) {
 	}
 
 	var durationMs float64
-	if startTime, ok := ev.Data["request_creation_time"].(string); ok {
-		tm, err := time.Parse(time.RFC3339Nano, startTime)
+	if endTime, ok := ev.Data["response_time"].(string); ok {
+		tm, err := time.Parse(time.RFC3339Nano, endTime)
 		if err == nil {
-			duration := ev.Timestamp.Sub(tm)
+			duration := tm.Sub(ev.Timestamp)
 			if duration > 0 {
 				durationMs = float64(duration / time.Millisecond)
 			}


### PR DESCRIPTION
There seems to be a difference in what the "time" field means in the access logs for different AWS services. In Cloudfront and ELB logs, the "time" field is the time the request was received. In ALB logs, the "time" field is the time the response was generated (relevant AWS docs: [Cloudfront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#StreamingDistributionLogFileFormat), [ELB](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/access-log-collection.html#access-log-entry-format), [ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-log-entry-syntax)). 

This change is to swap what field the timestamp variable is pointing at in the ALB logs integration so that it now points at the request_creation_time field. This will make it consistent with the other integrations and the trace flows now come out correctly in the Honeycomb UI.

This was tested in our setup, and resulting trace now looks correct:

![image](https://user-images.githubusercontent.com/74550527/106466219-f7c7c780-6492-11eb-8b76-a5121e5470f4.png)
