### PR TITLE
Adding filters to build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,10 @@ workflows:
   version: 2
   build:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              only: /.*/
       - build_packages:
           requires:
             - build


### PR DESCRIPTION
It seems that all jobs need at least a filter to be run on tags.