### PR TITLE
Prepare v1.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ### Added
 
-- Build and publish multi-arch docker images on tag (#153)
+- Build and publish multi-arch docker images on tag (#153) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
 
 ### Fixes
 
-- Fix building binaries commands so they pick up the GOOS and GOARCH vars (#97)
+- Fix building binaries commands so they pick up the GOOS and GOARCH vars (#97) | [@vreynolds](https://github.com/vreynolds)
+- Login to docker for publish_docker (#159) | [@jamiedanielson](https://github.com/jamiedanielson)
 
 ### Maintenance
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,3 +5,4 @@
 4. Create new tag on merged commit with the new version (e.g. `v1.4.1`)
 5. Push the tag upstream (this will kick off the release pipeline in CI)
 6. Copy change log entry for newest version into draft GitHub release created as part of CI publish steps
+7. Update [public docs](https://github.com/honeycombio/docs/blob/main/scripts)


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares the v1.4.1 release, including adding CHANGELOG and RELEASING markdown files.

## Short description of the changes
- add CHANGELOG.md file, with entry for 1.4.1
- add RELEASING.md file
