### PR TITLE
Login to docker for publish_docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,8 +160,8 @@ jobs:
           environment:
             KO_DOCKER_REPO: honeycombio
           command: |
-          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          ./build-docker.sh
+            echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin;
+            ./build_docker.sh
 
 workflows:
   version: 2


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Adds Docker Login for publishing images to Docker

## Short description of the changes

- In #153 we updated the build steps for multi-arch but during refactoring, missed the docker login step for publishing to docker. This adds the login step.

