### PR TITLE
Bump go version to 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   linuxgo:
     docker:
-      - image: cimg/go:1.16
+      - image: cimg/go:1.17
         environment:
           GO111MODULE: "on"
 
@@ -138,8 +138,7 @@ jobs:
           command: aws s3 sync ~/artifacts s3://honeycomb-builds/honeycombio/honeyaws/${CIRCLE_TAG}/
 
   build_docker:
-    docker:
-      - image: cimg/go:1.16
+    executor: linuxgo
     steps:
       - run: go install github.com/google/ko@latest
       - checkout
@@ -149,8 +148,7 @@ jobs:
           command: ./build-docker.sh
 
   publish_docker:
-    docker:
-      - image: cimg/go:1.16
+    executor: linuxgo
     steps:
       - run: go install github.com/google/ko@latest
       - checkout

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/honeyaws
 
-go 1.16
+go 1.17
 
 require (
 	github.com/aws/aws-sdk-go v1.41.5
@@ -11,4 +11,16 @@ require (
 	github.com/honeycombio/urlshaper v0.0.0-20170302202025-2baba9ae5b5f
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/sirupsen/logrus v1.8.1
+)
+
+require (
+	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
+	github.com/facebookgo/limitgroup v0.0.0-20150612190941-6abd8d71ec01 // indirect
+	github.com/facebookgo/muster v0.0.0-20150708232844-fd3d7953fd52 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/klauspost/compress v1.13.5 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.3.4 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	golang.org/x/sys v0.0.0-20210423082822-04245dca01da // indirect
+	gopkg.in/alexcesaro/statsd.v2 v2.0.0 // indirect
 )


### PR DESCRIPTION
### What is this PR solving?
Bumps go to v1.17

### Describe your changes
- bumps go to v1.17 in go.mod and images used in CircleCI 