### PR TITLE
Update awsclient orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,8 +128,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - aws-cli/install
-      - aws-cli/configure:
+      - aws-cli/setup:
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
           aws-region: AWS_REGION


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Updates the AWS CLI orb used in the CircleCI workflows to deploy artefacts. This image based on a Ubuntu image that will longer be avaialble soon.

- Closes #181  

## Short description of the changes
- update awscli orb version to latest (2.1.0)

