### PR TITLE
Fix readme instructions and add terraform snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ $ aws cloudformation create-stack --stack-name DynamoDBHoneyAWS \
     --template-body file://cloudformation/dynamoDB.yml
 ```
 
+We also have a [terraform snippet](terraform/dynamodb_table.tf) that you can use.
+
 Once this table is created, you can simply add the `--highavail` flag to
 `honeyelb` or `honeycloudfront`.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ for management of processed log files. There are a few things that must be
 set up before running `highavail`.
 
 First, a table must be created with the name `HoneyAWSAccessLogBuckets` with a
-primary key named `S3Object` and a sort key named `Time`. We also require that TTL be
+primary key named `S3Object`. We also require that TTL be
 enabled (we don't want your table to grow infinitely!) with the attribute name
 `TTL`. The TTL for objects is 7 days.
 

--- a/terraform/dynamodb_table.tf
+++ b/terraform/dynamodb_table.tf
@@ -1,0 +1,18 @@
+resource "aws_dynamodb_table" "honey_aws_access_log_bucket" {
+  name = "HoneyAWSAccessLogBuckets"
+
+  hash_key  = "S3Object"
+
+  attribute {
+    name = "S3Object"
+    type = "S"
+  }
+
+  read_capacity  = 10
+  write_capacity = 10
+
+  ttl {
+    attribute_name = "TTL"
+    enabled        = true
+  }
+}


### PR DESCRIPTION
The readme instructions are not up to date according to these two issues:

https://github.com/honeycombio/honeyaws/issues/42
https://github.com/honeycombio/honeyaws/pull/44


Also add a terraform snippet for the dynamo db table