### PR TITLE
Update go to 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   linuxgo:
     docker:
-      - image: cimg/go:1.17
+      - image: cimg/go:1.18
         environment:
           GO111MODULE: "on"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/honeyaws
 
-go 1.17
+go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.42.25


### PR DESCRIPTION
## Which problem is this PR solving?
Update go to latest version.

## Short description of the changes
- Updates go to v1.18 both in go.mod and circle CI image used to build binaries