### PR TITLE
Support Multiregion, Organization Trails, assuming role, and transmit Error Codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@
 infrastructure into [Honeycomb](https://www.honeycomb.io/), a service
 for debugging your software in production.
 
-- `honeyelb` - A tool for ingesting Elastic Load Balancer access logs.
-  ([docs](https://honeycomb.io/docs/connect/aws-elastic-load-balancer))
-- `honeyalb` - A tool for ingesting Application Load Balancer access logs.
-- `honeycloudfront` - A tool for ingesting CloudFront access logs.
-  ([docs](https://honeycomb.io/docs/connect/aws-cloudfront/))
-- `honeycloudtrail` - A tool for ingesting CloudTrail logs.
+-   `honeyelb` - A tool for ingesting Elastic Load Balancer access logs.
+    ([docs](https://honeycomb.io/docs/connect/aws-elastic-load-balancer))
+-   `honeyalb` - A tool for ingesting Application Load Balancer access logs.
+    ([docs](https://docs.honeycomb.io/getting-data-in/integrations/aws/aws-application-load-balancer/))
+-   `honeycloudfront` - A tool for ingesting CloudFront access logs.
+    ([docs](https://honeycomb.io/docs/connect/aws-cloudfront/))
+-   `honeycloudtrail` - A tool for ingesting CloudTrail logs.
+    ([docs](https://docs.honeycomb.io/getting-data-in/integrations/aws/aws-cloudtrail/))
 
 [Usage & Examples](https://docs.honeycomb.io/getting-data-in/integrations/aws/aws-elastic-load-balancer/)
 
@@ -33,7 +35,7 @@ above).
 Ensure that IAM credentials are properly provided where you are invoking the
 tools (e.g., via environment variables) and you have a Honeycomb write key.
 Additionally, you may need to enable access logs, etc., for whichever service
-you wish to ingest information from.  The S3 bucket where they are kept will be
+you wish to ingest information from. The S3 bucket where they are kept will be
 looked up automatically.
 
 Most commands can list the targets for observation (`ls`), as well as invoke
@@ -114,12 +116,12 @@ $ honeyelb --samplerate 20 ...  ingest ...
 You can choose between two implementations of dynamic sampling: `simple` or `ema`.
 Complete details about these implementations can be found [here](https://github.com/honeycombio/dynsampler-go).
 
-- `simple` looks at a single interval of traffic, defined by the `sampler_interval` arg, and computes sample rates
-based on counts of traffic categories seen in that interval. At every interval, the results of the previous interval
-are discarded.
-- `ema` averages observations from each interval into a moving average of counts, and computes sample rates based
-on those counts. Older observations are phased out at a rate specified by `sampler_decay`. Larger decay values mean that
-sample rates are more heavily influenced by newer traffic
+-   `simple` looks at a single interval of traffic, defined by the `sampler_interval` arg, and computes sample rates
+    based on counts of traffic categories seen in that interval. At every interval, the results of the previous interval
+    are discarded.
+-   `ema` averages observations from each interval into a moving average of counts, and computes sample rates based
+    on those counts. Older observations are phased out at a rate specified by `sampler_decay`. Larger decay values mean that
+    sample rates are more heavily influenced by newer traffic
 
 `simple` is suitable for most types of traffic, but we recommend using `ema` if your traffic comes in in bursts.
 

--- a/cmd/honeycloudtrail/README.md
+++ b/cmd/honeycloudtrail/README.md
@@ -1,0 +1,20 @@
+# Overview
+
+Honeycloudtrail ingests cloudtrail logs for single-region, multi-region, or Organization Cloud Trails.
+
+## Env Vars
+
+`HONEYCLOUDTRAIL_ROLE_ARN` - If you have created a special role for accessing your Cloud Trail, for example [per the AWS docs](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-sharing-logs.html), you can provide the arn as an environment variable, and honeycloudtrail will assume that role.
+
+Organization Cloud Trails by default are multiregion, and write all account logs to the same bucket. You can control which regions and accounts are ingested with these env vars. By default only the session's region and account logs will be ingested.
+
+`HONEYCLOUDTRAIL_COLLECT_REGIONS` - A comma-delimited list of regions used to specify which regions in an Organization trail should be ingested. If unset, the session's region will be used.
+ex: `HONEYCLOUDTRAIL_COLLECT_REGIONS=ap-northeast-1,eu-central-1,eu-west-1,us-east-2,us-west-1,us-west-2`
+
+`HONEYCLOUDTRAIL_COLLECT_ACCOUNTS` - A comma-delimited list of account ids, used to specify which accounts in an Organization trail should be ingested. If unset, the sessions account id will be used.
+ex: `HONEYCLOUDTRAIL_COLLECT_ACCOUNTS=12345678,66654321,98765555`
+
+## CLI Args
+
+-   `organization_id` - As discussed in the [AWS docs on locating Cloud Trail logs](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-find-log-files.html), Organization Cloud Trail s3 Paths will have the organization id in them. You can pass this in via the `organization_id` flag so that S3 paths will be properly formatted.
+-   `multiregion` - If you have multiregion cloudtrails or trails in regions other than the one honeycloudtrail is running in, pass in the `multiregion` flag to be able to see details on them.

--- a/cmd/honeycloudtrail/README.md
+++ b/cmd/honeycloudtrail/README.md
@@ -10,15 +10,18 @@ Honeycloudtrail ingests cloudtrail logs for single-region, multi-region, or Orga
 
 ### Multi-region and Organization Trails
 
-Organization Cloud Trails by default are multiregion, and write all account logs to the same bucket. You can control which regions and accounts are ingested with these env vars. By default only the session's region and account logs will be ingested.
+Organization Cloud Trails by default are multiregion, and write all account logs to the same bucket. You can control which regions and accounts are ingested with these env vars. By default only logs for the Trail's region and the session's account id will be ingested.
 
-`HONEYCLOUDTRAIL_COLLECT_REGIONS` - A comma-delimited list of regions used to specify which regions in an Organization trail should be ingested. If unset, the session's region will be used.
+`HONEYCLOUDTRAIL_COLLECT_REGIONS` - A comma-delimited list of regions used to specify which regions in an Organization trail should be ingested. If unset, the Trail's region will be used. If set, no other regions will be collected.
 ex: `HONEYCLOUDTRAIL_COLLECT_REGIONS=ap-northeast-1,eu-central-1,eu-west-1,us-east-2,us-west-1,us-west-2`
 
-`HONEYCLOUDTRAIL_COLLECT_ACCOUNTS` - A comma-delimited list of account ids, used to specify which accounts in an Organization trail should be ingested. If unset, the sessions account id will be used.
+`HONEYCLOUDTRAIL_COLLECT_ACCOUNTS` - A comma-delimited list of account ids, used to specify which accounts in an Organization trail should be ingested. If unset, the sessions account id will be used. If set, no other accounts will be collected.
 ex: `HONEYCLOUDTRAIL_COLLECT_ACCOUNTS=12345678,66654321,98765555`
 
 ## CLI Args
 
+### Multi-region and Organization Trails
+
 -   `organization_id` - As discussed in the [AWS docs on locating Cloud Trail logs](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-find-log-files.html), Organization Cloud Trail s3 Paths will have the organization id in them. You can pass this in via the `organization_id` flag so that S3 paths will be properly formatted.
--   `multiregion` - If you have multiregion cloudtrails or trails in regions other than the one honeycloudtrail is running in, pass in the `multiregion` flag to be able to see details on them.
+-   `find_trails_in_all_regions` - If you have multiregion cloudtrails or trails in regions other than the one honeycloudtrail is running in, pass in the `find_trails_in_all_regions` flag to be able to ingest them.
+-   `lsa` - Works like `ls`, but lists the cloudtrail ARN instead of the name. The ARN is required for describing and ingesting Trails outside the session region.

--- a/cmd/honeycloudtrail/README.md
+++ b/cmd/honeycloudtrail/README.md
@@ -4,7 +4,11 @@ Honeycloudtrail ingests cloudtrail logs for single-region, multi-region, or Orga
 
 ## Env Vars
 
-`HONEYCLOUDTRAIL_ROLE_ARN` - If you have created a special role for accessing your Cloud Trail, for example [per the AWS docs](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-sharing-logs.html), you can provide the arn as an environment variable, and honeycloudtrail will assume that role.
+### IAM
+
+`HONEYCLOUDTRAIL_ROLE_ARN` - If you have created a special role for accessing your Cloud Trail [per the AWS docs](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-sharing-logs.html), you can provide the arn as an environment variable, and honeycloudtrail will assume that role.
+
+### Multi-region and Organization Trails
 
 Organization Cloud Trails by default are multiregion, and write all account logs to the same bucket. You can control which regions and accounts are ingested with these env vars. By default only the session's region and account logs will be ingested.
 

--- a/cmd/honeycloudtrail/README.md
+++ b/cmd/honeycloudtrail/README.md
@@ -20,8 +20,11 @@ ex: `HONEYCLOUDTRAIL_COLLECT_ACCOUNTS=12345678,66654321,98765555`
 
 ## CLI Args
 
+-   `ls` - List the names of Cloud Trails visible to this profile
+-   `lsa` - Works like `ls`, but lists the cloudtrail name and ARN. The ARN is required for describing and ingesting Trails outside the session region.
+-   `--concurrency_limit` - An optional download concurrency limit to avoid rate limiting from AWS. The default behavior is to allow unlimited concurrency, which could result in a high volume of download requests for accounts with a large number of Cloud Trails.
+
 ### Multi-region and Organization Trails
 
--   `organization_id` - As discussed in the [AWS docs on locating Cloud Trail logs](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-find-log-files.html), Organization Cloud Trail s3 Paths will have the organization id in them. You can pass this in via the `organization_id` flag so that S3 paths will be properly formatted.
--   `find_trails_in_all_regions` - If you have multiregion cloudtrails or trails in regions other than the one honeycloudtrail is running in, pass in the `find_trails_in_all_regions` flag to be able to ingest them.
--   `lsa` - Works like `ls`, but lists the cloudtrail ARN instead of the name. The ARN is required for describing and ingesting Trails outside the session region.
+-   `--organization_id` - As discussed in the [AWS docs on locating Cloud Trail logs](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-find-log-files.html), Organization Cloud Trail s3 Paths will have the organization id in them. You can pass this in via the `organization_id` flag so that S3 paths will be properly formatted.
+-   `--find_trails_in_all_regions` - If you have multiregion cloudtrails or trails in regions other than the one honeycloudtrail is running in, pass in the `find_trails_in_all_regions` flag to be able to ingest them.

--- a/cmd/honeycloudtrail/main.go
+++ b/cmd/honeycloudtrail/main.go
@@ -89,7 +89,7 @@ Your write key is available at https://ui.honeycomb.io/account`)
 					var trailID string
 					// ARN is required to describe Trails belonging to other regions
 					// https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_DescribeTrails.html
-					if opt.MultiRegion {
+					if opt.FindTrailsInAllRegions {
 						trailID = *trail.TrailARN
 					} else {
 						trailID = *trail.Name
@@ -200,7 +200,7 @@ func main() {
 		logrus.Info("Organization ID provided, assuming Organization Cloud Trail")
 	}
 
-	if opt.MultiRegion {
+	if opt.FindTrailsInAllRegions {
 		logrus.Info("Multiregion set, will find trails in all regions")
 	}
 

--- a/cmd/honeycloudtrail/main.go
+++ b/cmd/honeycloudtrail/main.go
@@ -40,8 +40,6 @@ func init() {
 }
 
 func cmdCloudTrail(args []string) error {
-	// TODO: Would be nice to have this more highly configurable.
-	//
 	// Start with default profile.
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
@@ -71,7 +69,7 @@ func cmdCloudTrail(args []string) error {
 
 		case "lsa", "list-arn":
 			for _, trailSummary := range listTrailsResp.TrailList {
-				fmt.Println(*trailSummary.TrailARN)
+				fmt.Printf("%s: %s\n", *trailSummary.Name, *trailSummary.TrailARN)
 			}
 			return nil
 

--- a/logbucket/logbucket.go
+++ b/logbucket/logbucket.go
@@ -74,11 +74,10 @@ type CloudTrailDownloader struct {
 	Prefix, BucketName, AccountID, Region, TrailID, OrgID string
 }
 
-func NewCloudTrailDownloader(sess *session.Session, bucketName, bucketPrefix, trailID, orgID string) *CloudTrailDownloader {
-	metadata := meta.Data(sess)
+func NewCloudTrailDownloader(accountID, region, bucketName, bucketPrefix, trailID, orgID string) *CloudTrailDownloader {
 	return &CloudTrailDownloader{
-		AccountID:  metadata.AccountID,
-		Region:     metadata.Region,
+		AccountID:  accountID,
+		Region:     region,
 		BucketName: bucketName,
 		Prefix:     bucketPrefix,
 		TrailID:    trailID,

--- a/logbucket/logbucket.go
+++ b/logbucket/logbucket.go
@@ -208,7 +208,7 @@ func (d *Downloader) downloadObject(obj *s3.Object) error {
 
 func (d *Downloader) downloadObjects() {
 	for obj := range d.ObjectsToDownload {
-		d.ConcurrencyLimiter.WaitToRequest()
+		d.ConcurrencyLimiter.Acquire()
 		if err := d.downloadObject(obj); err != nil {
 			logrus.Error(err)
 		}
@@ -310,8 +310,8 @@ func NewConcurrencyLimit(limit int) *ConcurrencyLimit {
 	}
 }
 
-// WaitToRequest waits for a slot in the request semaphore to free up
-func (c *ConcurrencyLimit) WaitToRequest() {
+// Acquire waits for a slot in the request semaphore to free up
+func (c *ConcurrencyLimit) Acquire() {
 	start := time.Now()
 	c.requestSemaphore <- struct{}{}
 	waited := time.Since(start)
@@ -327,10 +327,10 @@ func (c *ConcurrencyLimit) Release() {
 // NoLimits is a no-op that does no concurrency limiting
 type NoLimits struct{}
 
-func (n NoLimits) WaitToRequest() {}
-func (n NoLimits) Release()       {}
+func (n NoLimits) Acquire() {}
+func (n NoLimits) Release() {}
 
 type ConcurrencyLimiter interface {
-	WaitToRequest()
+	Acquire()
 	Release()
 }

--- a/logbucket/logbucket_test.go
+++ b/logbucket/logbucket_test.go
@@ -39,6 +39,14 @@ func TestObjectPrefixes(t *testing.T) {
 			Prefix:     "",
 			TrailID:    "MADEUP0",
 		}, "AWSLogs/12345/CloudTrail/us-east-1/2018/08/20/12345_CloudTrail_us-east-1"},
+		{&CloudTrailDownloader{
+			AccountID:  "12345",
+			Region:     "us-east-1",
+			BucketName: "myorganizationlogs",
+			Prefix:     "",
+			TrailID:    "MADEUP0",
+			OrgID:      "o-FakeOrgID",
+		}, "AWSLogs/o-FakeOrgID/12345/CloudTrail/us-east-1/2018/08/20/12345_CloudTrail_us-east-1"},
 	}
 
 	for _, testCase := range testCases {

--- a/options/options.go
+++ b/options/options.go
@@ -1,19 +1,19 @@
 package options
 
 type Options struct {
-	Dataset          string  `short:"d" long:"dataset" description:"Name of the dataset" default:"aws-$SERVICE-access"`
-	SampleRate       int     `long:"samplerate" description:"Only send 1 / N log lines" default:"1"`
-	WriteKey         string  `short:"k" long:"writekey" description:"Honeycomb team write key"`
-	StateDir         string  `long:"statedir" description:"Directory where ingest state is stored" default:"."`
-	HighAvail        bool    `long:"highavail" description:"Enable high availability ingestion using DynamoDB"`
-	BackfillHr       int     `long:"backfill" description:"The number of hours to increase backfill of log ingestion to with max of 168 hours (1 week)" default:"1"`
-	EdgeMode         bool    `long:"edge_mode" description:"Ignore any parent trace id, if present, from a load balancer"`
-	SamplerType      string  `long:"sampler_type" default:"simple" description:"Type of dynamic sampler to use. Options are 'simple' and 'ema'"`
-	SamplerInterval  int     `long:"sampler_interval" default:"300" description:"Interval between sample rate calculation, in seconds."`
-	SamplerDecay     float64 `long:"sampler_decay" default:"0.5" description:"Used only when sampler_type is set to 'ema'. A value between (0,1) that controls how fast new observations are factored into the moving average. Larger values mean the sample rates are more sensitive to recent observations."`
-	OrganizationID   string  `long:"organization_id" description:"The organization id found in the S3 path for Organization cloud trails"`
-	MultiRegion      bool    `long:"multiregion" description:"Support accessing resources such as s3 buckets outside the session region"`
-	ConcurrencyLimit int     `long:"concurrency_limit" description:"Limit max concurrent access to CloudTrail S3 logs"`
+	Dataset                string  `short:"d" long:"dataset" description:"Name of the dataset" default:"aws-$SERVICE-access"`
+	SampleRate             int     `long:"samplerate" description:"Only send 1 / N log lines" default:"1"`
+	WriteKey               string  `short:"k" long:"writekey" description:"Honeycomb team write key"`
+	StateDir               string  `long:"statedir" description:"Directory where ingest state is stored" default:"."`
+	HighAvail              bool    `long:"highavail" description:"Enable high availability ingestion using DynamoDB"`
+	BackfillHr             int     `long:"backfill" description:"The number of hours to increase backfill of log ingestion to with max of 168 hours (1 week)" default:"1"`
+	EdgeMode               bool    `long:"edge_mode" description:"Ignore any parent trace id, if present, from a load balancer"`
+	SamplerType            string  `long:"sampler_type" default:"simple" description:"Type of dynamic sampler to use. Options are 'simple' and 'ema'"`
+	SamplerInterval        int     `long:"sampler_interval" default:"300" description:"Interval between sample rate calculation, in seconds."`
+	SamplerDecay           float64 `long:"sampler_decay" default:"0.5" description:"Used only when sampler_type is set to 'ema'. A value between (0,1) that controls how fast new observations are factored into the moving average. Larger values mean the sample rates are more sensitive to recent observations."`
+	OrganizationID         string  `long:"organization_id" description:"The organization id found in the S3 path for Organization cloud trails"`
+	FindTrailsInAllRegions bool    `long:"find_trails_in_all_regions" description:"Enable honeycloudtrail to describe trails outside the session region"`
+	ConcurrencyLimit       int     `long:"concurrency_limit" description:"Limit max concurrent access to CloudTrail S3 logs"`
 
 	Version bool   `short:"V" long:"version" description:"Show version"`
 	APIHost string `hidden:"true" long:"api_host" description:"Host for the Honeycomb API" default:"https://api.honeycomb.io/"`

--- a/options/options.go
+++ b/options/options.go
@@ -11,6 +11,8 @@ type Options struct {
 	SamplerType     string  `long:"sampler_type" default:"simple" description:"Type of dynamic sampler to use. Options are 'simple' and 'ema'"`
 	SamplerInterval int     `long:"sampler_interval" default:"300" description:"Interval between sample rate calculation, in seconds."`
 	SamplerDecay    float64 `long:"sampler_decay" default:"0.5" description:"Used only when sampler_type is set to 'ema'. A value between (0,1) that controls how fast new observations are factored into the moving average. Larger values mean the sample rates are more sensitive to recent observations."`
+	OrganizationID  string  `long:"organization_id" description:"The organization id found in the S3 path for Organization cloud trails"`
+	MultiRegion     bool    `long:"multiregion" description:"Support accessing resources such as s3 buckets outside the session region"`
 
 	Version bool   `short:"V" long:"version" description:"Show version"`
 	APIHost string `hidden:"true" long:"api_host" description:"Host for the Honeycomb API" default:"https://api.honeycomb.io/"`

--- a/options/options.go
+++ b/options/options.go
@@ -1,18 +1,19 @@
 package options
 
 type Options struct {
-	Dataset         string  `short:"d" long:"dataset" description:"Name of the dataset" default:"aws-$SERVICE-access"`
-	SampleRate      int     `long:"samplerate" description:"Only send 1 / N log lines" default:"1"`
-	WriteKey        string  `short:"k" long:"writekey" description:"Honeycomb team write key"`
-	StateDir        string  `long:"statedir" description:"Directory where ingest state is stored" default:"."`
-	HighAvail       bool    `long:"highavail" description:"Enable high availability ingestion using DynamoDB"`
-	BackfillHr      int     `long:"backfill" description:"The number of hours to increase backfill of log ingestion to with max of 168 hours (1 week)" default:"1"`
-	EdgeMode        bool    `long:"edge_mode" description:"Ignore any parent trace id, if present, from a load balancer"`
-	SamplerType     string  `long:"sampler_type" default:"simple" description:"Type of dynamic sampler to use. Options are 'simple' and 'ema'"`
-	SamplerInterval int     `long:"sampler_interval" default:"300" description:"Interval between sample rate calculation, in seconds."`
-	SamplerDecay    float64 `long:"sampler_decay" default:"0.5" description:"Used only when sampler_type is set to 'ema'. A value between (0,1) that controls how fast new observations are factored into the moving average. Larger values mean the sample rates are more sensitive to recent observations."`
-	OrganizationID  string  `long:"organization_id" description:"The organization id found in the S3 path for Organization cloud trails"`
-	MultiRegion     bool    `long:"multiregion" description:"Support accessing resources such as s3 buckets outside the session region"`
+	Dataset          string  `short:"d" long:"dataset" description:"Name of the dataset" default:"aws-$SERVICE-access"`
+	SampleRate       int     `long:"samplerate" description:"Only send 1 / N log lines" default:"1"`
+	WriteKey         string  `short:"k" long:"writekey" description:"Honeycomb team write key"`
+	StateDir         string  `long:"statedir" description:"Directory where ingest state is stored" default:"."`
+	HighAvail        bool    `long:"highavail" description:"Enable high availability ingestion using DynamoDB"`
+	BackfillHr       int     `long:"backfill" description:"The number of hours to increase backfill of log ingestion to with max of 168 hours (1 week)" default:"1"`
+	EdgeMode         bool    `long:"edge_mode" description:"Ignore any parent trace id, if present, from a load balancer"`
+	SamplerType      string  `long:"sampler_type" default:"simple" description:"Type of dynamic sampler to use. Options are 'simple' and 'ema'"`
+	SamplerInterval  int     `long:"sampler_interval" default:"300" description:"Interval between sample rate calculation, in seconds."`
+	SamplerDecay     float64 `long:"sampler_decay" default:"0.5" description:"Used only when sampler_type is set to 'ema'. A value between (0,1) that controls how fast new observations are factored into the moving average. Larger values mean the sample rates are more sensitive to recent observations."`
+	OrganizationID   string  `long:"organization_id" description:"The organization id found in the S3 path for Organization cloud trails"`
+	MultiRegion      bool    `long:"multiregion" description:"Support accessing resources such as s3 buckets outside the session region"`
+	ConcurrencyLimit int     `long:"concurrency_limit" description:"Limit max concurrent access to CloudTrail S3 logs"`
 
 	Version bool   `short:"V" long:"version" description:"Show version"`
 	APIHost string `hidden:"true" long:"api_host" description:"Host for the Honeycomb API" default:"https://api.honeycomb.io/"`

--- a/options/options.go
+++ b/options/options.go
@@ -13,7 +13,7 @@ type Options struct {
 	SamplerDecay           float64 `long:"sampler_decay" default:"0.5" description:"Used only when sampler_type is set to 'ema'. A value between (0,1) that controls how fast new observations are factored into the moving average. Larger values mean the sample rates are more sensitive to recent observations."`
 	OrganizationID         string  `long:"organization_id" description:"The organization id found in the S3 path for Organization cloud trails"`
 	FindTrailsInAllRegions bool    `long:"find_trails_in_all_regions" description:"Enable honeycloudtrail to describe trails outside the session region"`
-	ConcurrencyLimit       int     `long:"concurrency_limit" description:"Limit max concurrent access to CloudTrail S3 logs"`
+	ConcurrencyLimit       int     `long:"concurrency_limit" description:"[default: unlimited] Limit max concurrent access to CloudTrail S3 logs"`
 
 	Version bool   `short:"V" long:"version" description:"Show version"`
 	APIHost string `hidden:"true" long:"api_host" description:"Host for the Honeycomb API" default:"https://api.honeycomb.io/"`

--- a/publisher/cloudtrail.go
+++ b/publisher/cloudtrail.go
@@ -45,6 +45,8 @@ type CloudTrailRecord struct {
 	Resources         []CloudTrailResource   `json:"resources"`
 	EventType         string                 `json:"eventType"`
 	RequestParameters map[string]interface{} `json:"requestParameters"`
+	ErrorCode         string                 `json:"errorCode"`
+	ErrorMessage      string                 `json:"errorMessage"`
 }
 
 type CloudTrailEventParser struct {
@@ -69,6 +71,8 @@ func flattenCloudTrailRecord(r *CloudTrailRecord) map[string]interface{} {
 	p["UserAgent"] = r.UserAgent
 	p["EventType"] = r.EventType
 	p["Parameters"] = r.RequestParameters
+	p["ErrorCode"] = r.ErrorCode
+	p["ErrorMessage"] = r.ErrorMessage
 
 	return p
 }


### PR DESCRIPTION
Related Issues:
* resolves #118
* resolves #193
* resolves #194
* resolves #195 

These changes update Honeycloudtrail to support:

1. Ingesting trails that exist in multiple regions
2. Ingesting Organization Trails
3. Assuming a specific IAM role, which may be needed to access a particular cloudtrail
4. Transmit ErrorCode and ErrorMessage from the Cloudtrail log
5. Enable limiting of s3 download concurrency via a semaphore
6. Allow specifying multiple regions and accounts to consume for (in the case of Organization trails)

A major goal of this update was to gain the desired features without a large refactor, and without changing the default behavior of the tool for anyone relying on the defaults.
The only exception to this is that previously the session's region and account id would be used for the s3 path. Now, if no other env vars are set, the session account id and the Trail region will be used. This seems like a sensible default since the data is more likely to be in the region the trail is in over the region of the session, but this could be incorrect for some users (for instance, if they are running an ingester per region for a multiregion Trail). This behavior can be overridden with `HONEYCLOUDTRAIL_COLLECT_REGIONS`, but I'm also happy to roll it back to using the session defaults for everything.