### PR TITLE
maint: update docker orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@2.1.0
-  docker: circleci/docker@1.3.0
+  docker: circleci/docker@2.1.4
 
 executors:
   linuxgo:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- docker/publish job [failed](https://app.circleci.com/pipelines/github/honeycombio/honeyaws/365/workflows/332e10df-ebb5-43e9-9dda-b00f7c2ae4aa/jobs/678) in ci with "This job was rejected because the image is unavailable"

## Short description of the changes

- the docker orb version we were trying to use was really old --> bring it up to speed

## How to verify that this has the expected result

- I tried to dry run the job, but too many steps rely on a tag in the specific format 😩 
- the job did at least [start to run](https://app.circleci.com/pipelines/github/honeycombio/honeyaws/367/workflows/61174422-74ad-4bc1-9a1c-6e2c42f98648/jobs/685) so I'm fairly confident that it will work with a real release tag
