### PR TITLE
ci: remove duplicate docker publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,18 +202,6 @@ workflows:
               only: /^v[0-9].*/
             branches:
               ignore: /.*/
-      - docker/publish:
-          tag: latest,${CIRCLE_TAG:1}
-          extra_build_args: --build-arg BUILD_ID=${CIRCLE_TAG:1}
-          image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
-          requires:
-            - build_packages
-            - build_docker
-          filters:
-            tags:
-              only: /^v[0-9].*/
-            branches:
-              ignore: /.*/
       - publish_docker:
           context: Honeycomb Secrets for Public Repos
           requires:


### PR DESCRIPTION
We had both `docker/publish` and `publish_docker` in our build config. `docker/publish` seems to fail every time (presumably because it's using old secrets that have been removed) so let's just clean it up. `publish_docker` still gets our artifacts to DockerHub.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205014262861190